### PR TITLE
feat: add --data-align option

### DIFF
--- a/man/3cpio.1.adoc
+++ b/man/3cpio.1.adoc
@@ -14,7 +14,8 @@ Benjamin Drung
 
 *3cpio* *--count* _ARCHIVE_
 
-*3cpio* {*-c*|*--create*} [*-v*|*--debug*] [*-C* _DIR_] [_ARCHIVE_] < _manifest_
+*3cpio* {*-c*|*--create*} [*-v*|*--debug*] [*-C* _DIR_] [*--data-align* _ALIGNMENT_]
+[_ARCHIVE_] < _manifest_
 
 *3cpio* {*-e*|*--examine*} _ARCHIVE_
 
@@ -76,6 +77,30 @@ Following compression formats are supported: bzip2, gzip, lz4, lzma, lzop, xz, z
    Print help message.
 
 == Options
+
+*--data-align* _ALIGNMENT_::
+When creating a cpio archive, pad the cpio metadata to align the file data on
+_ALIGNMENT_ in bytes. This option is useful to reflink cpio file data on file
+systems that support reflinks.
+This padding/alignment will be skipped for files that are smaller than
+_ALIGNMENT_ and for cpio archives that are compressed.
+_ALIGNMENT_ must be a multiple of 4 bytes.
+This option is only taken into account in the *--create* mode.
++
+The resulting cpio archive may be highly fragmented, which can lead to performance
+degradation when reading/extracting the image from devices with slow random IO
+(e.g. spinning disk).
++
+**Note**: Using this option will "bend" the cpio newc spec a bit to inject
+zeros after the filename to provide data segment alignment. These zeros are
+accounted for in the namesize, but some applications may only expect a single
+zero-terminator (and 4 byte alignment). GNU cpio and Linux initramfs handle
+this fine as long as `PATH_MAX` is not exceeded.
++
+The following command can be used to determine the optimal tranfer size of the
+file system (where _$path_ is the path the cpio archive will be written to):
++
+  stat --file-system -c "%s" -- "$path"
 
 *-C* _DIR_, *--directory*=_DIR_::
   Change directory before performing any operation, but after opening the _ARCHIVE_.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,11 @@ pub fn print_cpio_archive_count<W: Write>(mut archive: File, out: &mut W) -> Res
 }
 
 // Return the size in bytes of the uncompressed data.
-pub fn create_cpio_archive(archive: Option<File>, log_level: u32) -> Result<u64> {
+pub fn create_cpio_archive(
+    archive: Option<File>,
+    alignment: Option<u32>,
+    log_level: u32,
+) -> Result<u64> {
     let source_date_epoch = get_source_date_epoch();
     let stdin = std::io::stdin();
     let buf_reader = std::io::BufReader::new(stdin);
@@ -290,7 +294,7 @@ pub fn create_cpio_archive(archive: Option<File>, log_level: u32) -> Result<u64>
     if log_level >= LOG_LEVEL_DEBUG {
         eprintln!("Writing cpio...");
     }
-    manifest.write_archive(archive, source_date_epoch, log_level)
+    manifest.write_archive(archive, alignment, source_date_epoch, log_level)
 }
 
 pub fn examine_cpio_content<W: Write>(mut archive: File, out: &mut W) -> Result<()> {

--- a/src/temp_dir.rs
+++ b/src/temp_dir.rs
@@ -3,8 +3,8 @@
 
 use std::env::{self, current_dir, set_current_dir};
 use std::fs::File;
-use std::io::{Read, Result};
-use std::path::PathBuf;
+use std::io::{Read, Result, Write};
+use std::path::{Path, PathBuf};
 
 pub struct TempDir {
     /// Path of the temporary directory.
@@ -13,6 +13,14 @@ pub struct TempDir {
 }
 
 impl TempDir {
+    /// Create a file in the temporary directory and return full path.
+    pub fn create<P: AsRef<Path>>(&self, filename: P, content: &[u8]) -> Result<String> {
+        let path = self.path.join(filename);
+        let mut file = File::create(&path)?;
+        file.write_all(content)?;
+        Ok(path.into_os_string().into_string().unwrap())
+    }
+
     /// Creates a new temporary directory.
     ///
     /// This temporary directory and all the files it contains will be removed


### PR DESCRIPTION
Add a `--data-align` option to the `--create` mode which will pad the cpio metadata to align the file data. This option is useful to reflink cpio file data on file systems that support reflinks.

**Note**: Using this option will "bend" the cpio newc spec a bit to inject zeros after the filename to provide data segment alignment. These zeros are accounted for in the namesize, but some applications may only expect a single zero-terminator (and 4 byte alignment). GNU cpio and Linux initramfs handle this fine as long as `PATH_MAX` is not exceeded.

Questions:
* Only pad if file data length > alignment?
* Not pad if compressed?