### PR TITLE
feat: introduce Logger struct and macros

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,9 +1,75 @@
 // Copyright (C) 2025, Benjamin Drung <bdrung@posteo.de>
 // SPDX-License-Identifier: ISC
 
+use std::io::{Stderr, Write};
+
 /// The warning level. Designates hazardous situations.
 pub const LOG_LEVEL_WARNING: u32 = 5;
 /// The info level. Designates useful information.
 pub const LOG_LEVEL_INFO: u32 = 7;
 /// The debug level. Designates lower priority information and for debugging.
 pub const LOG_LEVEL_DEBUG: u32 = 8;
+
+macro_rules! debug {
+    ($dst:ident, $($arg:tt)*) => {
+        if $dst.is_enabled_for_debug() {
+            writeln!($dst.out, $($arg)*)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+macro_rules! info {
+    ($dst:ident, $($arg:tt)*) => {
+        if $dst.is_enabled_for_info() {
+            writeln!($dst.out, $($arg)*)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+/// Simple logging implementation that logs to a writer and supports log levels.
+///
+/// In contrast to the common `log` crate, the `Logger` needs to be specified
+/// as parameter in the logging macros.
+#[derive(Debug)]
+pub struct Logger<W: Write> {
+    level: u32,
+    pub(crate) out: W,
+}
+
+impl<W: Write> Logger<W> {
+    pub(crate) fn is_enabled_for_debug(&self) -> bool {
+        self.level >= LOG_LEVEL_DEBUG
+    }
+
+    pub(crate) fn is_enabled_for_info(&self) -> bool {
+        self.level >= LOG_LEVEL_INFO
+    }
+}
+
+impl Logger<Stderr> {
+    /// Create a new `Logger` that logs to standard error (stderr).
+    pub fn new_stderr(level: u32) -> Self {
+        Self {
+            level,
+            out: std::io::stderr(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Logger<Vec<u8>> {
+    pub(crate) fn new_vec(level: u32) -> Self {
+        Self {
+            level,
+            out: Vec::new(),
+        }
+    }
+
+    pub(crate) fn get_logs(&self) -> &str {
+        core::str::from_utf8(&self.out).unwrap()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use glob::Pattern;
 use lexopt::prelude::*;
 
 use threecpio::extract::{extract_cpio_archive, ExtractOptions};
-use threecpio::logger::{LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARNING};
+use threecpio::logger::{Logger, LOG_LEVEL_DEBUG, LOG_LEVEL_INFO, LOG_LEVEL_WARNING};
 use threecpio::ranges::Ranges;
 use threecpio::{
     create_cpio_archive, examine_cpio_content, get_cpio_archive_count, list_cpio_content,
@@ -285,6 +285,7 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    let mut logger = Logger::new_stderr(args.log_level);
 
     if args.create {
         let mut archive = None;
@@ -307,7 +308,7 @@ fn main() -> ExitCode {
             );
             return ExitCode::FAILURE;
         }
-        let result = create_cpio_archive(archive, args.data_alignment, args.log_level);
+        let result = create_cpio_archive(archive, args.data_alignment, &mut logger);
         if let Err(error) = result {
             match error.kind() {
                 ErrorKind::BrokenPipe => {}
@@ -359,7 +360,7 @@ fn main() -> ExitCode {
                 archive,
                 args.to_stdout.then_some(&mut stdout),
                 &args.extract_options(),
-                args.log_level,
+                &mut logger,
             ),
         )
     } else if args.list {


### PR DESCRIPTION
Introduce a `Logger` struct and `debug!` and `info!` macros. This allows testing the log output.